### PR TITLE
refactor: #11 型定義を共通化

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,7 @@
 import axios from "axios";
 import { useState } from "react";
 import { List } from "./List";
-
-type ListType = {
-  userId: number;
-  id: number;
-  title: string;
-  completed: boolean;
-};
+import { ListType } from "./types/list";
 
 export default function App() {
   const [lists, setLists] = useState<Array<ListType>>([]);
@@ -20,7 +14,7 @@ export default function App() {
     <div>
       <button onClick={onClickFetchData}>データ取得</button>
       {lists.map((list) => (
-        <List title={list.title} userId={list.userId} completed={list.completed} />
+        <List key={list.id} title={list.title} userId={list.userId} completed={list.completed} />
       ))}
     </div>
   );

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -1,10 +1,6 @@
-type ListType = {
-  userId: number;
-  title: string;
-  completed: boolean;
-};
+import { ListType } from "./types/list";
 
-export const List = (props: ListType) => {
+export const List = (props: Omit<ListType, "id">) => {
   const { title, userId, completed = false } = props;
   const completeMark = completed ? "[完]" : "[未]";
   return <p>{`${completeMark} ${title}(ユーザー:${userId})`}</p>;

--- a/src/types/list.tsx
+++ b/src/types/list.tsx
@@ -1,0 +1,6 @@
+export type ListType = {
+  userId: number;
+  id: number;
+  title: string;
+  completed: boolean;
+};


### PR DESCRIPTION
## Issue Number
#11 型定義を効率的に管理できるようにする

## 内容
・型を定義する際に、コンポーネントで共通化しているものをコンポーネントして管理しやすいようにする

## 方法
typeで指定している部分を別コンポーネントにわけ、PickやOmitで必要なものを選別する